### PR TITLE
lors de la création d'un pattern, aucune image lui est associé. Cela …

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -68,10 +68,14 @@
 <div class="card-patterns">
   <% @patterns.sample(5).each do |pattern| %>
       <div class="parent" >
-        <div class="child bg-one" style="background: url('<%= cl_image_path pattern.photo.key %>'); background-size: cover;">
-          <div class="box-black">
+        <% if pattern.photo.attached? %>
+          <div class="child bg-one" style="background: url('<%= cl_image_path pattern.photo.key %>'); background-size: cover;">
+        <% else %>
+          <div class="child bg-one" style="background: url('<%= image_path "homepage/patterns/motif-test.png" %>'); background-size: cover;">
+        <% end %>
+            <div class="box-black">
+            </div>
           </div>
-        </div>
       </div>
   <% end %>
 </div>


### PR DESCRIPTION
…pose problème sur la homepage car on vient afficher les images de 5 pattern pris au pif: mais on aimerais que ce soit ceux crées via la seed car ils ont une image. Bref, on a ajouté une image placeholder si jamais le pattern ne vient pas de la seed, et n'a donc pas d'image associée.